### PR TITLE
Add jaxb dependency to logicrepository

### DIFF
--- a/logicrepository/pom.xml
+++ b/logicrepository/pom.xml
@@ -24,4 +24,11 @@
       </plugin>
     </plugins>
   </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.5</version>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
Issue: https://github.com/SoftEngResearch/tracemop/issues/25 (setup instructions are in the issue description)

Currently, we get the following errors when running `mvn clean package -DskipITs -DskipTests` in Java 11:
<img width="1402" alt="Screenshot 2023-07-27 at 4 43 24 PM" src="https://github.com/SoftEngResearch/tracemop/assets/53921230/29fb7e0f-9965-43c2-894f-b06710eaaed9">

This occurs because some packages used by logicrepository were available in Java 8 but deprecated and removed in Java 11 ([related forum](https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist)). We can fix this by adding the [old packages](https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime) as a dependency.

Output after making the changes in this PR (logicrepository now builds successfully):
<img width="1396" alt="Screenshot 2023-07-27 at 4 47 22 PM" src="https://github.com/SoftEngResearch/tracemop/assets/53921230/94ed7651-1a07-4864-b02b-83802af0181a">
